### PR TITLE
Make error types throwable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ The module exports various error predicates and the `.globalize()` method.
 
 The `.globalize()` method makes all the predicate functions available in global scope for convenience. If the name is already taken for a predicate in global scope, it will not be overwritten.
 
+Predicates can be turned into instances of their error types by using the `new` operator:
+
+```js
+try {
+  throw new FileNotFoundError("A file was not found!");
+}
+catch (e) {
+  assert(FileNotFoundError(e) === true);
+}
+```
+
 ##Error predicates
 
  - [`FileNotFoundError`](#filenotfounderror)

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function createClass(name, defaultCode, predicate) {
     var CustomError = (new Function('name', 'defaultCode', 'predicate', [
             '"use strict";',
             'return function ' + name + '(message, code) {',
-            '  if (this === undefined) return predicate(message);',
+            '  if (this === undefined) return message instanceof ' + name + ' ? true : predicate(message);',
             '  Error.captureStackTrace(this, "' + name + '");',
             '  Error.call(this);',
             '  this.name = name;',

--- a/test/test.js
+++ b/test/test.js
@@ -32,42 +32,42 @@ function testType(type, codes) {
             });
 
             describe("creates new instance, without arguments", function () {
-              specify(code, function () {
-                var instance = new predicate();
-                assert.strictEqual(instance instanceof Error, true);
-                assert.strictEqual(instance instanceof predicate, true);
-                assert.strictEqual(instance.code, codes[0]);
-              });
+                specify(code, function () {
+                    var instance = new predicate();
+                    assert.strictEqual(instance instanceof Error, true);
+                    assert.strictEqual(instance instanceof predicate, true);
+                    assert.strictEqual(instance.code, codes[0]);
+                });
             });
 
             describe("creates a new instance, with message argument", function () {
-              specify(code, function () {
-                var instance = new predicate("Something went wrong");
-                assert.strictEqual(instance.code, codes[0]);
-                assert.strictEqual(instance.message, "Something went wrong");
-              });
+                specify(code, function () {
+                    var instance = new predicate("Something went wrong");
+                    assert.strictEqual(instance.code, codes[0]);
+                    assert.strictEqual(instance.message, "Something went wrong");
+                });
             });
 
             describe("creates a new instance, with message and code arguments", function () {
-              specify(code, function () {
-                var instance = new predicate("Something went wrong", code);
-                assert.strictEqual(instance.code, code);
-                assert.strictEqual(instance.message, "Something went wrong");
-              });
+                specify(code, function () {
+                    var instance = new predicate("Something went wrong", code);
+                    assert.strictEqual(instance.code, code);
+                    assert.strictEqual(instance.message, "Something went wrong");
+                });
             });
 
             describe("predicate matches instance with default code", function () {
-              specify(code, function () {
-                var instance = new predicate();
-                assert.strictEqual(predicate(instance), true);
-              });
+                specify(code, function () {
+                    var instance = new predicate();
+                    assert.strictEqual(predicate(instance), true);
+                });
             });
 
             describe("predicate matches instance with specific code", function () {
-              specify(code, function () {
-                var instance = new predicate("Error", code);
-                assert.strictEqual(predicate(instance), true);
-              });
+                specify(code, function () {
+                    var instance = new predicate("Error", code);
+                    assert.strictEqual(predicate(instance), true);
+                });
             });
 
         });
@@ -77,13 +77,18 @@ function testType(type, codes) {
             assert.strictEqual(predicate(Object.create(null)), false);
         });
 
-        it('should be throwable', function () {
-          try {
-            throw new predicate("Error");
-          }
-          catch (e) {
-            assert.strictEqual(predicate(e), true);
-          }
+        it("matches instance with specific code, even if the code is not recognized", function () {
+            var instance = new predicate("Error", "nonsense");
+            assert.strictEqual(predicate(instance), true);
+        });
+
+        it('is throwable', function () {
+            try {
+                throw new predicate("Error");
+            }
+            catch (e) {
+                assert.strictEqual(predicate(e), true);
+            }
         });
     });
 }
@@ -127,5 +132,19 @@ describe("SSLError", function() {
     specify("doesn't cause errors with weird objects", function() {
         assert.strictEqual(SSLError(false), false);
         assert.strictEqual(SSLError(Object.create(null)), false);
+    });
+
+    it("matches instance with specific code, even if the code is not recognized", function () {
+        var instance = new SSLError("Error", "nonsense");
+        assert.strictEqual(SSLError(instance), true);
+    });
+
+    it('is throwable', function () {
+        try {
+            throw new SSLError("Error");
+        }
+        catch (e) {
+            assert.strictEqual(SSLError(e), true);
+        }
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -30,11 +30,60 @@ function testType(type, codes) {
                     assert.strictEqual(predicate(errorWithCause(code)), true);
                 });
             });
+
+            describe("creates new instance, without arguments", function () {
+              specify(code, function () {
+                var instance = new predicate();
+                assert.strictEqual(instance instanceof Error, true);
+                assert.strictEqual(instance instanceof predicate, true);
+                assert.strictEqual(instance.code, codes[0]);
+              });
+            });
+
+            describe("creates a new instance, with message argument", function () {
+              specify(code, function () {
+                var instance = new predicate("Something went wrong");
+                assert.strictEqual(instance.code, codes[0]);
+                assert.strictEqual(instance.message, "Something went wrong");
+              });
+            });
+
+            describe("creates a new instance, with message and code arguments", function () {
+              specify(code, function () {
+                var instance = new predicate("Something went wrong", code);
+                assert.strictEqual(instance.code, code);
+                assert.strictEqual(instance.message, "Something went wrong");
+              });
+            });
+
+            describe("predicate matches instance with default code", function () {
+              specify(code, function () {
+                var instance = new predicate();
+                assert.strictEqual(predicate(instance), true);
+              });
+            });
+
+            describe("predicate matches instance with specific code", function () {
+              specify(code, function () {
+                var instance = new predicate("Error", code);
+                assert.strictEqual(predicate(instance), true);
+              });
+            });
+
         });
 
         it("doesn't cause errors with weird objects", function() {
             assert.strictEqual(predicate(false), false);
             assert.strictEqual(predicate(Object.create(null)), false);
+        });
+
+        it('should be throwable', function () {
+          try {
+            throw new predicate("Error");
+          }
+          catch (e) {
+            assert.strictEqual(predicate(e), true);
+          }
         });
     });
 }


### PR DESCRIPTION
It seems a waste to add things like `FileNotFoundError` to the global namespace but not make it possible for users to `throw new FileNotFoundError()`. This PR fixes that by detecting when the `new` operator is being used and instantiating a custom error type with the appropriate error code.
